### PR TITLE
Makes start game button exclusive to owner

### DIFF
--- a/lib/controller/game_controller.dart
+++ b/lib/controller/game_controller.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:have_you_heard/models/game.dart';
 import 'package:have_you_heard/models/player.dart';
 import 'package:have_you_heard/models/socket.dart';
+import 'package:have_you_heard/ui/vote_persona.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class GameController extends GetxController {
@@ -80,4 +81,8 @@ class GameController extends GetxController {
     socket.joinRoom(roomID);
   }
 
+  void startGame(){
+    socket.startGame();
+    Get.offNamed(VotePersonaScreen.route);
+  }
 }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -11,18 +11,19 @@ class Game {
     'Pergunta 3',
   ];
 
-  int nPlayers = 0;
+  RxInt nPlayers = 0.obs;
   // The list always has a length of 6
   List<Player> playerList = <Player>[].obs;
+  RxString ownerID = 'not_set'.obs;
 
   Game();
 
   void setPlayers(List<dynamic> players, Player myPlayer) {
-    nPlayers = players.length;
+    nPlayers.value = players.length;
     playerList.clear();
     for (var index = 0; index < 6; index++) {
       Player player = Player(name:'Jogador ${index + 1}');
-      if (index < nPlayers) {
+      if (index < nPlayers.value) {
         player = Player.fromJson(players[index]);
       }
       if (myPlayer.id == player.id) {

--- a/lib/models/socket.dart
+++ b/lib/models/socket.dart
@@ -51,6 +51,7 @@ class Socket {
       var room = jsonDecode(data);
       String roomID = room['id'].substring(5);
       gc.roomID = roomID;
+      gc.game.ownerID.value = room['ownerID'];
 
       gc.game.setPlayers(room['users'], gc.myPlayer);
       Get.toNamed("${RoomScreen.route}/$roomID");
@@ -73,5 +74,9 @@ class Socket {
     socket.emit('leave');
     Get.offAllNamed(LobbyScreen.route);
 
+  }
+
+  void startGame() {
+    socket.emit('start');
   }
 }

--- a/lib/ui/room.dart
+++ b/lib/ui/room.dart
@@ -10,8 +10,6 @@ import 'package:have_you_heard/widgets/app_button.dart';
 import 'package:have_you_heard/widgets/game_exit_dialog.dart';
 import 'package:have_you_heard/widgets/gray_stripe.dart';
 
-import 'vote_persona.dart';
-
 class RoomScreen extends StatefulWidget {
   const RoomScreen({Key? key}) : super(key: key);
 
@@ -78,17 +76,23 @@ class _RoomScreenState extends State<RoomScreen> {
                       for (var index = 0; index < 6; index++)
                         buildPlayerButton(index),
                       SizedBox(height: appBarHeight * 0.67),
-                      AppButton(
-                        color: kPinkButton,
-                        width: screenWidth * 0.8,
-                        onPressed: () {
-                          Get.offNamed(VotePersonaScreen.route);
-                        },
-                        child: Text(
-                          'startGame'.tr,
-                          style: kElevatedButtonTextStyle,
+                      Obx(() => Visibility(
+                        maintainSize: true,
+                        maintainAnimation: true,
+                        maintainState: true,
+                        visible: (gc.game.ownerID.value == gc.myPlayer.id) ? true : false,
+                        child: AppButton(
+                          color: kPinkButton,
+                          width: screenWidth * 0.8,
+                          onPressed: (gc.game.nPlayers.value >= 1) ? () {
+                            gc.startGame();
+                          } : null,
+                          child: Text(
+                            'startGame'.tr,
+                            style: kElevatedButtonTextStyle,
+                          ),
                         ),
-                      ),
+                      )),
                     ],
                   ),
                 ),
@@ -118,13 +122,13 @@ class _RoomScreenState extends State<RoomScreen> {
                   padding: EdgeInsets.symmetric(horizontal: appBarHeight * 0.2),
                   child: Obx(() => Text(gc.game.playerList[index].name))
               ),
-              Visibility(
-                child: const Icon(Icons.check),
+              Obx(()  => Visibility(
+                child: const Icon(Icons.star_rate_rounded),
                 maintainSize: true,
                 maintainAnimation: true,
                 maintainState: true,
-                visible: loadingValues[0] == 1 ? true : false,
-              )
+                visible: (gc.game.playerList[index].id == gc.game.ownerID.value) ? true : false,
+              )),
             ],
           ),
         ]),

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -12,7 +12,7 @@ class AppButton extends StatelessWidget {
   }) : super(key: key);
 
   final Color color;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
   final Widget child;
   final double width;
 


### PR DESCRIPTION
- Only show the 'start game' button to the room owner.
- Only enable the button when a certain number of players is in the room.
  Currently the limit is set to 1. The owner can play alone, :)
- Substitute the check icon for a star icon. It will be used to signal the owner.