### PR TITLE
Fix exception in animation timer

### DIFF
--- a/lib/ui/game_winner.dart
+++ b/lib/ui/game_winner.dart
@@ -51,7 +51,7 @@ class _GameWinnerScreenState extends State<GameWinnerScreen> {
 
   startAnimationTimer() async {
     var duration = const Duration(seconds: 1);
-    return Timer(duration, animationProgressTimer());
+    return Timer(duration, animationProgressTimer);
   }
 
   animationProgressTimer() async {


### PR DESCRIPTION
Fixes the following exception:
```
E/flutter (32751): [ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: type 'Future<dynamic>' is not a subtype of type '() => void'
E/flutter (32751): #0      _GameWinnerScreenState.startAnimationTimer (package:have_you_heard/ui/game_winner.dart:54:28)
E/flutter (32751): #1      _GameWinnerScreenState.initState (package:have_you_heard/ui/game_winner.dart:44:5)
```