### PR TITLE
Handle start game event

### DIFF
--- a/lib/controller/game_controller.dart
+++ b/lib/controller/game_controller.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:have_you_heard/models/game.dart';
+import 'package:have_you_heard/models/room.dart';
 import 'package:have_you_heard/models/player.dart';
 import 'package:have_you_heard/models/socket.dart';
 import 'package:have_you_heard/ui/vote_persona.dart';
@@ -10,6 +11,7 @@ class GameController extends GetxController {
   String roomID = '42069';
   Player myPlayer = Player();
 
+  Room room = Room();
   Game game = Game();
   Socket socket = Socket();
 

--- a/lib/controller/game_controller.dart
+++ b/lib/controller/game_controller.dart
@@ -4,7 +4,6 @@ import 'package:have_you_heard/models/game.dart';
 import 'package:have_you_heard/models/room.dart';
 import 'package:have_you_heard/models/player.dart';
 import 'package:have_you_heard/models/socket.dart';
-import 'package:have_you_heard/ui/vote_persona.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class GameController extends GetxController {
@@ -73,6 +72,5 @@ class GameController extends GetxController {
 
   void startGame(){
     socket.startGame();
-    Get.offNamed(VotePersonaScreen.route);
   }
 }

--- a/lib/controller/game_controller.dart
+++ b/lib/controller/game_controller.dart
@@ -20,20 +20,8 @@ class GameController extends GetxController {
     getOnboardedState();
   }
 
-  void nextRound() {
-    game.roundIndex += 1;
-  }
-
-  bool isGameFinished() {
-    return game.roundIndex >=3;
-  }
-
-  void reset() {
-    game.roundIndex = 0;
-  }
-
   void exitGame() {
-    reset();
+    game.reset();
     socket.leaveRoom();
   }
 

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -51,4 +51,20 @@ class Game {
     allHeadlines.clear();
     allHeadlines.assignAll(headlines);
   }
+
+  String getBlankHeadline() {
+    return allHeadlines[roundIndex];
+  }
+
+  String getWinnerHeadline() {
+    String currentHeadline = allHeadlines[roundIndex];
+    String winnerHeadline = currentHeadline.replaceAll(RegExp(r'_+'), '(Resposta X)');
+    return winnerHeadline;
+  }
+
+  String getCorrectHeadline() {
+    String currentHeadline = allHeadlines[roundIndex];
+    String correctHeadline = currentHeadline.replaceAll(RegExp(r'_+'), '(Correta)');
+    return correctHeadline;
+  }
 }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -14,7 +14,6 @@ class Game {
   RxInt nPlayers = 0.obs;
   // The list always has a length of 6
   List<Player> playerList = <Player>[].obs;
-  RxString ownerID = 'not_set'.obs;
 
   Game();
 

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -53,16 +53,25 @@ class Game {
   }
 
   String getBlankHeadline() {
+    if (roundIndex >= allHeadlines.length) {
+      return "";
+    }
     return allHeadlines[roundIndex];
   }
 
   String getWinnerHeadline() {
+    if (roundIndex >= allHeadlines.length) {
+      return "";
+    }
     String currentHeadline = allHeadlines[roundIndex];
     String winnerHeadline = currentHeadline.replaceAll(RegExp(r'_+'), '(Resposta X)');
     return winnerHeadline;
   }
 
   String getCorrectHeadline() {
+    if (roundIndex >= allHeadlines.length) {
+      return "";
+    }
     String currentHeadline = allHeadlines[roundIndex];
     String correctHeadline = currentHeadline.replaceAll(RegExp(r'_+'), '(Correta)');
     return correctHeadline;

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -5,11 +5,12 @@ import 'package:have_you_heard/models/player.dart';
 
 class Game {
   int roundIndex = 0;
-  List<String> allNews = [
+  List<String> allHeadlines = [
     'Pergunta 1',
     'Pergunta 2',
     'Pergunta 3',
   ];
+  int persona = -1;
 
   RxInt nPlayers = 0.obs;
   // The list always has a length of 6
@@ -44,5 +45,10 @@ class Game {
         playerList.add(player);
       }
     }
+  }
+
+  void setHeadlines(List<String> headlines) {
+    allHeadlines.clear();
+    allHeadlines.assignAll(headlines);
   }
 }

--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -18,6 +18,18 @@ class Game {
 
   Game();
 
+  void nextRound() {
+    roundIndex += 1;
+  }
+
+  bool isGameFinished() {
+    return roundIndex >=3;
+  }
+
+  void reset() {
+    roundIndex = 0;
+  }
+
   void setPlayers(List<dynamic> players, Player myPlayer) {
     nPlayers.value = players.length;
     playerList.clear();

--- a/lib/models/room.dart
+++ b/lib/models/room.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/cupertino.dart';
+
+import 'package:get/get.dart';
+import 'package:have_you_heard/models/player.dart';
+
+class Room {
+
+  RxInt nUsers = 0.obs;
+  // The list always has a length of 6
+  List<Player> userList = <Player>[].obs;
+  RxString ownerID = 'not_set'.obs;
+
+  Room();
+
+  void setUsers(List<dynamic> users, Player myUser) {
+    nUsers.value = users.length;
+    userList.clear();
+    for (var index = 0; index < 6; index++) {
+      Player user = Player(name:'Jogador ${index + 1}');
+      if (index < nUsers.value) {
+        user = Player.fromJson(users[index]);
+      }
+      if (myUser.id == user.id) {
+        // Always show myself as the first in the list of users
+        userList.insert(0, user);
+      } else {
+        userList.add(user);
+      }
+    }
+  }
+}

--- a/lib/models/socket.dart
+++ b/lib/models/socket.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:have_you_heard/ui/lobby.dart';
 import 'package:have_you_heard/ui/room.dart';
+import 'package:have_you_heard/ui/vote_persona.dart';
+
 import 'package:socket_io_client/socket_io_client.dart' as sio;
 
 import 'package:have_you_heard/controller/game_controller.dart';
@@ -55,6 +57,20 @@ class Socket {
 
       gc.room.setUsers(room['users'], gc.myPlayer);
       Get.toNamed("${RoomScreen.route}/$roomID");
+    });
+
+    socket.on('game', (data) {
+      final GameController gc = Get.find();
+      var game = jsonDecode(data);
+      gc.game.setHeadlines(List<String>.from(game['headlines']));
+      gc.game.setPlayers(game['players'], gc.myPlayer);
+
+      // Navigation
+      String currentRoute = Get.currentRoute;
+      if (currentRoute.startsWith('/room')) {
+          Get.offNamed(VotePersonaScreen.route);
+      }
+
     });
   }
 

--- a/lib/models/socket.dart
+++ b/lib/models/socket.dart
@@ -51,9 +51,9 @@ class Socket {
       var room = jsonDecode(data);
       String roomID = room['id'].substring(5);
       gc.roomID = roomID;
-      gc.game.ownerID.value = room['ownerID'];
+      gc.room.ownerID.value = room['ownerID'];
 
-      gc.game.setPlayers(room['users'], gc.myPlayer);
+      gc.room.setUsers(room['users'], gc.myPlayer);
       Get.toNamed("${RoomScreen.route}/$roomID");
     });
   }

--- a/lib/ui/correct_news.dart
+++ b/lib/ui/correct_news.dart
@@ -119,10 +119,8 @@ class _CorrectNewsScreenState extends State<CorrectNewsScreen> {
                                     fontWeight: FontWeight.bold,
                                     color: kGrayScaleDarkest)),
                             balloonText: RichText(
-                                text: const TextSpan(
-                                    text:
-                                    'Lorem ipsum dolor sit amet, consectetur {RESPOSTA X} '
-                                        'elit ut aliquam, purus sit amet luctus venenatis, lectus',
+                                text:  TextSpan(
+                                    text: gc.game.getCorrectHeadline(),
                                     style: TextStyle(
                                         height: 1.5,
                                         fontSize: 16,

--- a/lib/ui/correct_news.dart
+++ b/lib/ui/correct_news.dart
@@ -39,8 +39,8 @@ class _CorrectNewsScreenState extends State<CorrectNewsScreen> {
   }
 
   route() {
-    gc.nextRound();
-    if (gc.isGameFinished()) {
+    gc.game.nextRound();
+    if (gc.game.isGameFinished()) {
       Get.offNamed(GameWinnerScreen.routeName);
     } else {
       Get.offNamed(ShowNewsScreen.routeName);

--- a/lib/ui/game_winner.dart
+++ b/lib/ui/game_winner.dart
@@ -97,7 +97,7 @@ class _GameWinnerScreenState extends State<GameWinnerScreen> {
                 ElevatedButton(
                     onPressed: () {
                       // Reinstate a new Game State
-                      gc.reset();
+                      gc.game.reset();
                       String roomID = gc.roomID;
                       Get.offAllNamed("${RoomScreen.route}/$roomID");
                     },

--- a/lib/ui/room.dart
+++ b/lib/ui/room.dart
@@ -80,11 +80,11 @@ class _RoomScreenState extends State<RoomScreen> {
                         maintainSize: true,
                         maintainAnimation: true,
                         maintainState: true,
-                        visible: (gc.game.ownerID.value == gc.myPlayer.id) ? true : false,
+                        visible: (gc.room.ownerID.value == gc.myPlayer.id) ? true : false,
                         child: AppButton(
                           color: kPink,
                           width: screenWidth * 0.8,
-                          onPressed: (gc.game.nPlayers.value >= 1) ? () {
+                          onPressed: (gc.room.nUsers.value >= 1) ? () {
                             gc.startGame();
                           } : null,
                           child: Text(
@@ -120,14 +120,14 @@ class _RoomScreenState extends State<RoomScreen> {
             children: [
               Padding(
                   padding: EdgeInsets.symmetric(horizontal: appBarHeight * 0.2),
-                  child: Obx(() => Text(gc.game.playerList[index].name))
+                  child: Obx(() => Text(gc.room.userList[index].name))
               ),
               Obx(()  => Visibility(
                 child: const Icon(Icons.star_rate_rounded),
                 maintainSize: true,
                 maintainAnimation: true,
                 maintainState: true,
-                visible: (gc.game.playerList[index].id == gc.game.ownerID.value) ? true : false,
+                visible: (gc.room.userList[index].id == gc.room.ownerID.value) ? true : false,
               )),
             ],
           ),

--- a/lib/ui/round_winner.dart
+++ b/lib/ui/round_winner.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:flutter_svg_provider/flutter_svg_provider.dart';
 import 'package:have_you_heard/constants/colors.dart';
+import 'package:have_you_heard/controller/game_controller.dart';
 import 'correct_news.dart';
 import 'package:have_you_heard/widgets/chat_balloon.dart';
 
@@ -55,6 +56,7 @@ class _RoundWinnerScreenState extends State<RoundWinnerScreen> {
   Widget build(BuildContext context) {
     var screenWidth = MediaQuery.of(context).size.width;
     final appBarHeight = AppBar().preferredSize.height;
+    final GameController gc = Get.find();
 
     return WillPopScope(
       // This is short lived screen, let's block the back button
@@ -105,10 +107,8 @@ class _RoundWinnerScreenState extends State<RoundWinnerScreen> {
                                 fontSize: 16,
                                 fontWeight: FontWeight.bold)),
                         balloonText: RichText(
-                            text: const TextSpan(
-                                text: 'Lorem ipsum dolor sit amet, consectetur '
-                                    '{RESPOSTA X} elit ut aliquam, purus sit amet '
-                                    'luctus venenatis, lectus',
+                            text:  TextSpan(
+                                text: gc.game.getWinnerHeadline(),
                                 style: TextStyle(height: 1.5, fontSize: 16)))),
                     Image(
                       alignment: Alignment.centerRight,

--- a/lib/ui/show_news.dart
+++ b/lib/ui/show_news.dart
@@ -54,8 +54,8 @@ class _ShowNewsScreenState extends State<ShowNewsScreen> {
                   child: ChatBalloon(
                     balloonHeader: const Text('Você ouviu que...'),
                     balloonText: RichText(
-                        text: const TextSpan(
-                            text: 'Lorem ipsum dolor sit amet, consectetur _____ elit ut aliquam, purus sit amet luctus venenatis, lectus',
+                        text: TextSpan(
+                            text: gc.game.getBlankHeadline(),
                             style: TextStyle(
                                 fontSize: 16.0,
                                 height: 1.5

--- a/lib/ui/vote_answer.dart
+++ b/lib/ui/vote_answer.dart
@@ -69,10 +69,8 @@ class _VoteAnswerScreenState extends State<VoteAnswerScreen> {
                         'Você ouviu que ...',
                         style: TextStyle(height: 1.5, fontSize: 16, fontWeight: FontWeight.bold)),
                     balloonText: RichText(
-                        text: const TextSpan(
-                            text: 'Lorem ipsum dolor sit amet, consectetur _____ '
-                                'elit ut aliquam, purus sit amet luctus '
-                                'venenatis, lectus',
+                        text: TextSpan(
+                            text: gc.game.getBlankHeadline(),
                             style: TextStyle(
                                 fontSize: 16.0,
                                 height: 1.5


### PR DESCRIPTION
- Reacts to the 'game' event
  - Takes in the received headlines and use them during the game.
  - Transitions to the VotePersona Screen, as the event was received while in the Room Screen.
- Splits `Game` into `Room` and `Game` to better reflect the data structure and flow.
  - Basically, the `Room` can have a different set of Players than the `Game` :exploding_head: 
- 