### PR TITLE
Fix disposal of waiting screen

### DIFF
--- a/lib/ui/waiting_screen.dart
+++ b/lib/ui/waiting_screen.dart
@@ -40,8 +40,8 @@ class _WaitingScreenState extends State<WaitingScreen>
 
   @override
   void dispose() {
-    super.dispose();
     _controller.dispose();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
The controller should be disposed before the mixin ticker.