### PR TITLE
Auto user transitions need to be cancelable

### DIFF
--- a/lib/ui/show_news.dart
+++ b/lib/ui/show_news.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:have_you_heard/constants/colors.dart';
@@ -22,6 +24,7 @@ class _ShowNewsScreenState extends State<ShowNewsScreen>
     with SingleTickerProviderStateMixin {
   // The player has 12 seconds to answer the news
   final Duration _screenDuration = const Duration(seconds: 12);
+  late final Timer _timer;
 
   late final AnimationController _controller = AnimationController(
     duration: _screenDuration,
@@ -44,9 +47,7 @@ class _ShowNewsScreenState extends State<ShowNewsScreen>
       setState(() {});
     });
 
-    Future.delayed(_screenDuration, () {
-      sendAnswer();
-    });
+    _timer = Timer(_screenDuration, sendAnswer);
   }
 
   @override
@@ -57,6 +58,7 @@ class _ShowNewsScreenState extends State<ShowNewsScreen>
   }
 
   sendAnswer() {
+    _timer.cancel();
     gc.sendAnswer(textController.text);
     var parameters = <String, String>{"titleFlag": "true", "bannerText": "Esperando respostas"};
     Get.offNamed(WaitingScreen.route, parameters: parameters);

--- a/lib/ui/vote_answer.dart
+++ b/lib/ui/vote_answer.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -22,6 +24,7 @@ class VoteAnswerScreen extends StatefulWidget {
 class _VoteAnswerScreenState extends State<VoteAnswerScreen>
     with SingleTickerProviderStateMixin {
   final Duration _screenDuration = const Duration(seconds: 7);
+  late final Timer _timer;
 
   late final AnimationController _controller = AnimationController(
     duration: _screenDuration,
@@ -45,9 +48,7 @@ class _VoteAnswerScreenState extends State<VoteAnswerScreen>
       setState(() {});
     });
 
-    Future.delayed(_screenDuration, () {
-      sendVote();
-    });
+    _timer = Timer(_screenDuration, sendVote);
   }
 
   @override
@@ -182,6 +183,7 @@ class _VoteAnswerScreenState extends State<VoteAnswerScreen>
   }
 
   void sendVote() {
+    _timer.cancel();
     gc.voteAnswer(votedAnswer);
     var parameters = <String, String>{"titleFlag": "true", "bannerText": "Esperando votos"};
     Get.offNamed(WaitingScreen.route, parameters: parameters);


### PR DESCRIPTION
User transitions by time out need to be cancelable when the user acts before them.
Otherwise the transition will happen again, after the user has provided his input.

Follow up from #61 