### PR TITLE
Fix app init and user name

### DIFF
--- a/lib/controller/game_controller.dart
+++ b/lib/controller/game_controller.dart
@@ -56,7 +56,6 @@ class GameController extends GetxController {
 
   void setPlayerName(String playerName) {
     myPlayer.name = playerName;
-    socket.initUser(playerName);
   }
 
   void saveUser(String username) async {

--- a/lib/controller/game_controller.dart
+++ b/lib/controller/game_controller.dart
@@ -56,6 +56,7 @@ class GameController extends GetxController {
 
   void setPlayerName(String playerName) {
     myPlayer.name = playerName;
+    socket.sendName(playerName);
   }
 
   void saveUser(String username) async {

--- a/lib/models/socket.dart
+++ b/lib/models/socket.dart
@@ -45,8 +45,6 @@ class Socket {
     socket.on('user id', (data) {
       final GameController gc = Get.find();
       gc.myPlayer.id = data;
-
-      socket.emit('name', gc.myPlayer.name);
     });
 
     // We have just entered a room
@@ -114,7 +112,9 @@ class Socket {
   }
   void sendLang(String lang) {
     socket.emit('language', lang);
-
+  }
+  void sendName(String name) {
+    socket.emit('name', name);
   }
 
   void createRoom() {

--- a/lib/ui/splash.dart
+++ b/lib/ui/splash.dart
@@ -25,7 +25,8 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   initState() {
     super.initState();
-
+    final GameController gc = Get.find();
+    gc.socket.initUser("");
     Future.delayed(const Duration(seconds: 4), () {
       showLang();
     });


### PR DESCRIPTION
- The first thing the app needs to do is to request a new user from the server.
  - This should fix problems users not being able to join some rooms. The 'langauge' event is ignored when 'user' is not emitted first.
- Organize the 'name' event a little bit.

