### PR TITLE
Auto join the room when we reconnect

### DIFF
--- a/lib/controller/game_controller.dart
+++ b/lib/controller/game_controller.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 class GameController extends GetxController {
   String roomID = 'none';
+  String previousRoomID = 'none';
   Player myPlayer = Player();
 
   Room room = Room();

--- a/lib/models/socket.dart
+++ b/lib/models/socket.dart
@@ -52,6 +52,10 @@ class Socket {
         // Workaround for Redis
         gc.sendLanguage();
       });
+      if (gc.roomID != 'none') {
+        // Auto join room
+        gc.joinRoom(gc.roomID);
+      }
     });
 
     // We have just entered a room
@@ -137,6 +141,9 @@ class Socket {
   }
 
   void leaveRoom() {
+    final GameController gc = Get.find();
+    gc.previousRoomID = gc.roomID;
+    gc.roomID = 'none';
     socket.emit('leave');
     Get.offAllNamed(LobbyScreen.route);
 

--- a/lib/ui/lobby.dart
+++ b/lib/ui/lobby.dart
@@ -136,7 +136,7 @@ class _LobbyScreenState extends State<LobbyScreen> {
                   ),
                 ),
                 Visibility(
-                  visible: gc.roomID == 'none' ? false : true,
+                  visible: gc.previousRoomID == 'none' ? false : true,
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
@@ -154,9 +154,9 @@ class _LobbyScreenState extends State<LobbyScreen> {
                             EdgeInsets.symmetric(horizontal: screenWidth * 0.1),
                         child: IconAppButton(
                           onPressed: () {
-                            gc.joinRoom(gc.roomID);
+                            gc.joinRoom(gc.previousRoomID);
                           },
-                          text: 'returnToRoom'.trParams({'roomNumber': gc.roomID}),
+                          text: 'returnToRoom'.trParams({'roomNumber': gc.previousRoomID}),
                           color: kPink,
                           textColor: kGrayScaleLightest,
                         ),


### PR DESCRIPTION
In case of network issues the socket.io may disconnect and connect again, in this case,
lets rejoin the room we were previously in.

- Added a new field 'previousRoomId`
  - We need a way to differentiate between the previous room and the current room, otherwise, when there is a network issue, we may end up reconnecting to the previous room when we didn't mean to.