### PR TITLE
Cancel timers when quitting the game

### DIFF
--- a/lib/ui/show_news.dart
+++ b/lib/ui/show_news.dart
@@ -54,6 +54,7 @@ class _ShowNewsScreenState extends State<ShowNewsScreen>
 
   @override
   void dispose() {
+    _timer.cancel();
     _controller.dispose();
     textController.dispose();
     super.dispose();

--- a/lib/ui/vote_answer.dart
+++ b/lib/ui/vote_answer.dart
@@ -53,6 +53,7 @@ class _VoteAnswerScreenState extends State<VoteAnswerScreen>
 
   @override
   void dispose() {
+    _timer.cancel();
     _controller.dispose();
     super.dispose();
   }


### PR DESCRIPTION
This avoids the player being directed to the waiting screen even after leaving the game.