### PR TITLE
Remove Cupertino

### DIFF
--- a/lib/models/game.dart
+++ b/lib/models/game.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/cupertino.dart';
-
 import 'package:get/get.dart';
 import 'package:have_you_heard/models/player.dart';
 

--- a/lib/models/room.dart
+++ b/lib/models/room.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/cupertino.dart';
-
 import 'package:get/get.dart';
 import 'package:have_you_heard/models/player.dart';
 

--- a/lib/ui/room.dart
+++ b/lib/ui/room.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/widgets.dart';

--- a/lib/ui/vote_answer.dart
+++ b/lib/ui/vote_answer.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:have_you_heard/constants/colors.dart';

--- a/lib/widgets/close_game_dialog.dart
+++ b/lib/widgets/close_game_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:get/get_utils/src/extensions/internacionalization.dart';

--- a/lib/widgets/won_game_dialog.dart
+++ b/lib/widgets/won_game_dialog.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg_provider/flutter_svg_provider.dart';
 import 'package:get/get_utils/src/extensions/internacionalization.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,13 +43,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  #cupertino_icons: ^1.0.2
   get:
 
 dev_dependencies:


### PR DESCRIPTION
The Cupertino package is only used for iOS builds.